### PR TITLE
H2O-1389 adds case for changeset with non-string values

### DIFF
--- a/lib/ja_serializer/ecto_error_serializer.ex
+++ b/lib/ja_serializer/ecto_error_serializer.ex
@@ -36,7 +36,12 @@ if Code.ensure_loaded?(Ecto) do
       errors =
         Ecto.Changeset.traverse_errors(cs, fn({msg, validation_opts}) ->
           Enum.reduce(validation_opts, msg, fn {key, value}, acc ->
-            String.replace(acc, "%{#{key}}", to_string(value))
+            # Some error options cannot be represented as a string (noteably tuples), so we
+            # ignore them when modifying the message so that it doesn't break `String.replace/3`.
+            case String.Chars.impl_for(value) do
+              nil -> acc
+              _impl -> String.replace(acc, "%{#{key}}", to_string(value))
+            end
           end)
         end)
 

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -3,6 +3,26 @@ defmodule JaSerializer.EctoErrorSerializerTest do
 
   alias JaSerializer.EctoErrorSerializer
 
+  test "Will correctly ignore options from error message when there are not formatable" do
+    expected = %{
+      "errors" => [
+        %{
+          detail: "Title is invalid for reason: %{reason}",
+          source: %{pointer: "/data/attributes/title"},
+          title: "is invalid for reason: %{reason}"
+        }
+      ],
+      "jsonapi" => %{"version" => "1.0"}
+    }
+
+    changeset =
+      {%{}, %{title: :string}}
+      |> Ecto.Changeset.cast(%{}, [])
+      |> Ecto.Changeset.add_error(:title, "is invalid for reason: %{reason}", reason: {})
+
+    assert expected == EctoErrorSerializer.format(changeset)
+  end
+
   test "Will correctly format a changeset with an error" do
     expected = %{
       "errors" => [

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -3,7 +3,7 @@ defmodule JaSerializer.EctoErrorSerializerTest do
 
   alias JaSerializer.EctoErrorSerializer
 
-  test "Will correctly ignore options from error message when there are not formatable" do
+  test "Will correctly ignore options from error message when they are not formattable" do
     expected = %{
       "errors" => [
         %{


### PR DESCRIPTION
## [H20-1389](https://peeksters.atlassian.net/browse/H2O-1389)

## What

Adds a case to ensure non-string values are handled properly in changesets.

This has been tested locally and tests are passing. This PR must be pushed first before we can push this [4754](https://github.com/gadabout/noreaga/pull/4754) in Noreaga

## Why

When the value is a tuple, it fails to convert the value properly and an error `Protocol.UndefinedError` is thrown preventing the changeset to be presented.

```elixir
# deps/ja_serializer/lib/ja_serializer/ecto_error_serializer.ex:36

Ecto.Changeset.traverse_errors(cs, fn({msg, validation_opts}) ->
  Enum.reduce(validation_opts, msg, fn {key, value}, acc ->
    String.replace(acc, "%{#{key}}", to_string(value)) # <------------ HERE
  end)
end)
```

## Risk Assessment

- [ ] **1** It's only tests, documentation, or has extremely good test coverage.
- [ ] **2** Check to make sure it does what it says it does, doesn't require much of a deep dive/regression testing.
- [X] **3** Normal feature, bang on it and find the edge cases I missed.
- [ ] **4** Sensitive stuff… don’t under-estimate the complexity.
- [ ] **5** Danger, stranger!

## Code Familiarity

- [X] **1** I've never touched this part of the world before.
- [ ] **2** I'm starting to understand this neck of the woods.
- [ ] **3** I know this stuff in and out.

## Deployment Implications

- [ ] Schema migrations included
- [ ] Data migrations needed; link ticket:
- [ ] Backwards incompatible (no rollback possible)
- [ ] Requires other service changes to be deployed first, please list:

## Testing Instructions

*Instructions to QA on what touchpoints need special attention*
